### PR TITLE
Fix automated undo logic with trailing snapshots

### DIFF
--- a/flippory/flippory.js
+++ b/flippory/flippory.js
@@ -673,7 +673,12 @@ App.undo = function(shiftKey) {
   else {
     let automatedEndIndex = App.getAutomatedEnd?.();
     // undo the automated step
-    if (automatedEndIndex === this.history.length - 1) {
+    let lastHistoryIndex = this.history.length - 1;
+    // skip any trailing snapshots
+    while (lastHistoryIndex >= 0 && this.history[lastHistoryIndex]?.fn === "snapshot") {
+      lastHistoryIndex--;
+    }
+    if (automatedEndIndex === lastHistoryIndex) {
       
       trace(`--- --- App.undoing A`);
       let automatedStartIndex = App.getAutomatedStart?.();


### PR DESCRIPTION
## Summary
- Skip trailing `snapshot` entries when determining if the last history entry is an automated step
- Undo automated actions correctly even when a snapshot follows `automated-end`

## Testing
- `node --check flippory/flippory.js`


------
https://chatgpt.com/codex/tasks/task_b_68955f2a28b88320978f11b07993bb5a