### PR TITLE
Avoid getImageData on large canvas in Safari

### DIFF
--- a/flippory/flippory.js
+++ b/flippory/flippory.js
@@ -280,9 +280,30 @@ App.getMaxCanvasDimension = function(){
 App.canvasFailed = function(canvas){
   try {
     const ctx = canvas.getContext("2d");
-    const pixel = ctx.getImageData(0, 0, 1, 1).data;
+
+    if (!ctx || canvas.width === 0 || canvas.height === 0) {
+      return true;
+    }
+
+    if (!App._pixelProbeCanvas) {
+      App._pixelProbeCanvas = document.createElement("canvas");
+      App._pixelProbeCanvas.width = 1;
+      App._pixelProbeCanvas.height = 1;
+      App._pixelProbeContext = App._pixelProbeCanvas.getContext("2d");
+    }
+
+    const probeContext = App._pixelProbeContext;
+
+    if (!probeContext) {
+      return true;
+    }
+
+    probeContext.clearRect(0, 0, 1, 1);
+    probeContext.drawImage(canvas, 0, 0, 1, 1, 0, 0, 1, 1);
+
+    const pixel = probeContext.getImageData(0, 0, 1, 1).data;
     return pixel[3] === 0; // transparent = failed draw
-  } 
+  }
   catch (e) {
     return true; // error = failure
   }


### PR DESCRIPTION
## Summary
- sample the drawn pixel using a 1x1 offscreen canvas to avoid iOS Safari crashes when calling getImageData on large canvases
- add guards for missing contexts or zero-sized canvases to treat the draw as failed safely

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6912f2b7b86883209fd939ce1872cb46)