### PR TITLE
Fix HEIC load error messaging

### DIFF
--- a/flippory/flippory.js
+++ b/flippory/flippory.js
@@ -1524,20 +1524,21 @@ Flipper.prototype.rotate = function(counterclockwise){
 
 //----------------------------------------------------- 
 Flipper.prototype.loadImage = function(fileOrURL, callback, onImageLoad){
+  var isHeic = (fileOrURL instanceof File || fileOrURL instanceof Blob) && (fileOrURL.type === "image/heic" || fileOrURL.type === "image/heif");
   $(this.image).one("load", function(url){
     onImageLoad(this.src);
   });
   $(this.image).one("error", function(){
     var message = "Could not load image.";
-    if (fileOrURL instanceof File && (fileOrURL.type === "image/heic" || fileOrURL.type === "image/heif")) {
+    if (isHeic) {
       message = "This browser does not support HEIC images.";
     }
     trace(message);
     alert(message);
   });
-  this.image.src = " ";
+  this.image.removeAttribute("src");
   if(fileOrURL instanceof File || fileOrURL instanceof Blob){
-    if (fileOrURL.type === "image/heic" || fileOrURL.type === "image/heif") {
+    if (isHeic) {
       if (window.createImageBitmap) {
         createImageBitmap(fileOrURL)
           .then(function(bitmap){


### PR DESCRIPTION
### Motivation
- Prevent spurious error dialog when importing HEIC/HEIF files that are later decoded and displayed.
- Centralize HEIC detection logic to avoid repeating the same checks in multiple places.
- Avoid resetting the image `src` to a blank string which can trigger an unnecessary error event.

### Description
- Introduced a single `isHeic` boolean to detect HEIC/HEIF files from `File`/`Blob` inputs.
- Use `this.image.removeAttribute("src")` instead of `this.image.src = " "` to avoid emitting an error on reset.
- Replace repeated `fileOrURL.type` checks with the `isHeic` variable and keep the `createImageBitmap` decode path for HEIC.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69642e1cd5208320b05a00ead7e94504)